### PR TITLE
Use correct brew url for install

### DIFF
--- a/cleanmachine
+++ b/cleanmachine
@@ -56,7 +56,7 @@ if ! command_exists "brew"; then
 	echo "\n"
 	echo "Installing Homebrew"
 
-	ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/homebrew/go/install)"
+	ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 fi
 
 if ! command_exists "brew"; then


### PR DESCRIPTION
Fixes #2 Where the install fails due to a 404 on the home-brew install script.